### PR TITLE
Fix up example to use correct object

### DIFF
--- a/pydexarm/example.py
+++ b/pydexarm/example.py
@@ -3,7 +3,7 @@ from pydexarm import Dexarm
 '''windows'''
 dexarm = Dexarm(port="COM67")
 '''mac & linux'''
-# device = Dexarm(port="/dev/tty.usbmodem3086337A34381")
+# dexarm = Dexarm(port="/dev/tty.usbmodem3086337A34381")
 
 dexarm.go_home()
 


### PR DESCRIPTION
Currently the example fails with: python3 pydexarm/example.py
pydexarm: /dev/ttyACM0 open
Traceback (most recent call last):
  File "/home/michele/Devel/DexArm_API/pydexarm/example.py", line 9, in <module>
    dexarm.go_home()
NameError: name 'dexarm' is not defined

Let's point it to the proper class so things start working again.
Renaming 'dexarm' instead of 'device' in order to make it less
confusing.

Signed-off-by: Michele Baldessari <michele@acksyn.org>